### PR TITLE
improve errors for non-200 status codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func fetchAll(ctx context.Context, feeds []*url.URL) []*Post {
 
 			feedData, err := fetchFeed(ctxTimeout, feed, 0)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+				fmt.Fprintf(os.Stderr, "ERROR: failed fetching feed %q: %v\n", feed, err)
 				return
 			}
 
@@ -253,7 +253,7 @@ func fetchFeed(ctx context.Context, feedUrl *url.URL, depth int) (*gofeed.Feed, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%d: %s", resp.StatusCode, resp.Status)
+		return nil, fmt.Errorf("Unexpected status code: %s", resp.Status)
 	}
 
 	contents, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This PR improves the error messages around non-200 HTTP status codes from feeds. If a feed isn't found or the server 500s, picofeed prints the error message but does not print the feed on which the error occurred. 

This PR adds the offending feed to the error message and makes the error message for non-200 status codes clearer by removing the redundant status code.